### PR TITLE
test: make FileSystemFileSystemWatcherTest pass on macOS

### DIFF
--- a/lib/src/test/java/io/github/raphiz/hotswap/FileSystemFileSystemWatcherTest.java
+++ b/lib/src/test/java/io/github/raphiz/hotswap/FileSystemFileSystemWatcherTest.java
@@ -159,8 +159,8 @@ public class FileSystemFileSystemWatcherTest {
     private void waitUntil(ThrowingRunnable assertion) {
         boolean isMacOS = System.getProperty("os.name").toLowerCase().contains("mac os");
         Awaitility.await()
-                .pollInterval(50, TimeUnit.MILLISECONDS)
-                .atMost(isMacOS ? 2 : 250, TimeUnit.SECONDS)
+                .pollInterval(10, TimeUnit.MILLISECONDS)
+                .atMost(isMacOS ? 2_500 : 250, TimeUnit.MILLISECONDS)
                 .untilAsserted(() -> {
                     try {
                         assertion.run();

--- a/lib/src/test/java/io/github/raphiz/hotswap/FileSystemFileSystemWatcherTest.java
+++ b/lib/src/test/java/io/github/raphiz/hotswap/FileSystemFileSystemWatcherTest.java
@@ -157,9 +157,10 @@ public class FileSystemFileSystemWatcherTest {
     }
 
     private void waitUntil(ThrowingRunnable assertion) {
+        boolean isMacOS = System.getProperty("os.name").toLowerCase().contains("mac os");
         Awaitility.await()
-                .pollInterval(10, TimeUnit.MILLISECONDS)
-                .atMost(250, TimeUnit.MILLISECONDS)
+                .pollInterval(50, TimeUnit.MILLISECONDS)
+                .atMost(isMacOS ? 2 : 250, TimeUnit.SECONDS)
                 .untilAsserted(() -> {
                     try {
                         assertion.run();


### PR DESCRIPTION
macOS's file system event system (FSEvents) has a higher latency, and may batch events together, so we increase the timeouts in the test to account for this.